### PR TITLE
Add support for invert table format.

### DIFF
--- a/cli/xraycli
+++ b/cli/xraycli
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 from __future__ import unicode_literals
 from __future__ import print_function
-import sys
+import click
 import os
 from tabulate import tabulate
 from pandas import DataFrame
@@ -11,6 +11,7 @@ import warnings
 warnings.simplefilter("ignore")
 import nanomsg
 from xray_client.XrayClient import XrayClient
+
 
 class NoNodesError(Exception):
     pass
@@ -40,11 +41,11 @@ def humanize_number(value, fraction_point=1):
 
 class XrayCli(object):
     XRAY_NODES_PATH = '/tmp/xray/'
-    
+
     def __init__(self):
         self.nodes_list = self.get_nodes()
         self.nodes = {}
-        
+
     def get_nodes(self):
         try:
             nodes = os.listdir(self.XRAY_NODES_PATH)
@@ -65,7 +66,7 @@ class XrayCli(object):
         if node_name not in self.nodes:
             self.nodes[node_name] = XrayClient(node_name)
         return self.nodes[node_name].send_recv(node_xpath, fmt)
-    
+
     def humanize_column(self, column):
         return [humanize_number(int(value)) for value in column]
 
@@ -80,7 +81,7 @@ class XrayCli(object):
         except nanomsg.NanoMsgAPIError:
             print("Timeout. Cannot access path " + full_xpath)
             return
-        
+
         if fmt == 'json':
             print(json.dumps(result_set))
         else:
@@ -88,7 +89,12 @@ class XrayCli(object):
             self.huminify_rates(df)
             if query:
                 df = df.query(query)
-            print(tabulate(df, headers=df.columns, showindex=False, tablefmt='simple'))
+            if fmt == 'table':
+                print(tabulate(df, headers=df.columns, showindex=False, tablefmt='simple'))
+            else:
+                itable = [(key + ':',) + tuple(val.values())
+                          for key, val in df.to_dict().items()]
+                print(tabulate(itable, showindex=False, tablefmt='plain'))
 
     def close(self):
         for node in self.nodes:
@@ -98,25 +104,20 @@ class XrayCli(object):
                 pass
 
 
-def usage():
-    print("usage:")
-    print("\txraycli <path> <path>... [--json]")
+@click.command()
+@click.option('--format', '-f',
+              default='table',
+              help='The wanted output format',
+              type=click.Choice(['json', 'table', 'itable']))
+@click.argument('paths', required=True, nargs=-1)
+def main(format, paths):
+    xcli = XrayCli()
+    try:
+        for path in paths:
+            xcli.run(path, None, format)
+    finally:
+        xcli.close()
 
 
 if __name__ == "__main__":
-    fmt = 'table'
-    if len(sys.argv) <= 1:
-        usage()
-        exit(-1)
-    xcli = XrayCli()
-    try:
-        if sys.argv[-1] == '--json':
-            fmt = 'json'
-            args = sys.argv[1:-1]
-        else:
-            args = sys.argv[1:]
-
-        for arg in args:
-            xcli.run(arg, None, fmt)
-    finally:
-        xcli.close()
+    main()

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
         'nanomsg',
         'tabulate',
         'pandas',
+        'click',
     ],
     license='MIT',
     scripts=['cli/xraycli']

--- a/src/test-app.c
+++ b/src/test-app.c
@@ -33,6 +33,11 @@ typedef struct basic_types {
     char *p_str;
 } basic_types_t;
 
+struct itable_example {
+	int a;
+	int b;
+	int c;
+};
 
 typedef struct ctest {
 	int id;
@@ -81,6 +86,22 @@ register_basic_types()
 	xray_add_slot(basic_types_t, p_str, c_p_string_t, 0);
 
     xray_register(basic_types_t, &basic_types, "/basic_types", ARR_DIM(basic_types), NULL);
+}
+
+static void
+register_itable()
+{
+    	static struct itable_example element = {
+		.a = 1,
+		.b = 2,
+		.c = 3,
+    	};
+    	xray_create_type(struct itable_example, NULL);
+	xray_add_slot(struct itable_example, a, int, 0);
+	xray_add_slot(struct itable_example, b, int, 0);
+	xray_add_slot(struct itable_example, c, int, 0);
+
+    	xray_register_struct(struct itable_example, &element, "/itable");
 }
 
 
@@ -158,6 +179,7 @@ int main() {
     register_is_up();
     register_test();
     register_basic_types();
+    register_itable();
     test_unregister();
 
 	while(exit_test == 0) {

--- a/src/xray.h
+++ b/src/xray.h
@@ -66,6 +66,9 @@ extern "C"
 	#define xray_register(container, obj, path, n_rows, iterator) \
 		_xray_register(#container, obj, path, n_rows, iterator)
 
+	#define xray_register_struct(container, obj, path)  \
+		xray_register(container, obj, path, 1, NULL)
+
 	#define xray_create_type(container, fmt_type_cb) \
 		_xray_create_type(#container, sizeof(container), fmt_type_cb)
 	#define xray_add_slot(container, slot, slot_type, flags) \
@@ -76,7 +79,5 @@ extern "C"
 #ifdef __cplusplus
 }
 #endif
-
-
 
 #endif /* SRC_XRAY_H_ */

--- a/src/xray.hpp
+++ b/src/xray.hpp
@@ -115,6 +115,4 @@ public:
 	void handle_rxloop();
 };
 
-
-
 #endif /* SRC_XRAY_HPP_ */

--- a/test/test_system.py
+++ b/test/test_system.py
@@ -32,7 +32,7 @@ class TestApp:
         self._start_testapp()
 
     def run_cmd(self, path):
-        result = check_output(['xraycli', '/test-app' + path, '--json'])
+        result = check_output(['xraycli', '-f', 'json', '/test-app' + path])
         js = json.loads(result)
 
         return js['result_set']


### PR DESCRIPTION
Allowing users to create "one line" tables.
This is useful for printing structures instead of a table.

```
xraycli -f itable /test-app/itable       
a:  1                
c:  3                
b:  2                

xraycli -f table /test-app/itable        
  a    b    c        
---  ---  ---        
  1    2    3        

```