### PR TITLE
Add XRAY_HIDDEN_FLAG

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ MAINTAINER grisha85
 
 RUN apt-get update -y
 RUN apt-get install -y python build-essential python-pip libnanomsg-dev
-RUN pip install nanomsg tabulate pandas # xraycli deps
 ADD . /libxray
+RUN pip install /libxray
 WORKDIR /libxray

--- a/cli/xraycli_completion.sh
+++ b/cli/xraycli_completion.sh
@@ -10,7 +10,6 @@ _xray_cli_complete()
                 _xraycli_paths=''
                 _xray_num_services="${num_services}"
                 while read -r service; do
-                        echo getting options for ${service}
                         while read -r table; do
                                 _xraycli_paths="${_xraycli_paths} ${service}${table}"
                         done <<< "$(xraycli ${service} | tail -n +3)"

--- a/src/test-app.c
+++ b/src/test-app.c
@@ -98,7 +98,7 @@ register_itable()
     	};
     	xray_create_type(struct itable_example, NULL);
 	xray_add_slot(struct itable_example, a, int, 0);
-	xray_add_slot(struct itable_example, b, int, 0);
+	xray_add_slot(struct itable_example, b, int, XRAY_SLOT_FLAG_HIDDEN);
 	xray_add_slot(struct itable_example, c, int, 0);
 
     	xray_register_struct(struct itable_example, &element, "/itable");
@@ -109,8 +109,8 @@ static void
 register_test()
 {
     xray_create_type(ctest_t, NULL);
-	xray_add_slot(ctest_t, id, int, XRAY_FLAG_PK);
-	xray_add_slot(ctest_t, rate, int, XRAY_FLAG_RATE);
+	xray_add_slot(ctest_t, id, int, XRAY_SLOT_FLAG_PK);
+	xray_add_slot(ctest_t, rate, int, XRAY_SLOT_FLAG_HIDDEN | XRAY_SLOT_FLAG_RATE);
 	xray_add_vslot(ctest_t, "b", add_one);
 	xray_register(ctest_t, &test_inst, "/a/c", sizeof(test_inst)/sizeof(test_inst[0]), NULL);
 	xray_register(ctest_t, &test_inst, "/rate", 1, NULL);

--- a/src/xray.h
+++ b/src/xray.h
@@ -19,9 +19,10 @@ extern "C"
 	#define XRAY_MAX_SLOT_STR_SIZE 	(64)
 	#define XRAY_STATE_MAX_SIZE 	(32)
 
-	#define XRAY_FLAG_CONST (1 << 0)
-	#define XRAY_FLAG_RATE  (1 << 1)
-	#define XRAY_FLAG_PK	(1 << 2)
+	#define XRAY_SLOT_FLAG_CONST 	(1 << 0)
+	#define XRAY_SLOT_FLAG_RATE  	(1 << 1)
+	#define XRAY_SLOT_FLAG_PK	(1 << 2)
+	#define XRAY_SLOT_FLAG_HIDDEN	(1 << 3)
 
 	#define member_size(type, member) sizeof(((type *)0)->member)
 


### PR DESCRIPTION
The new XRAY_HIDDEN_FLAG allows the user to mark a specific slot as
hidden. This is useful for scenarios with PK values that shouldn't be
displayed.