### PR TITLE
Add hex type to enable hex printable types

### DIFF
--- a/src/xray.cpp
+++ b/src/xray.cpp
@@ -703,6 +703,7 @@ void XNode::register_basic_types(void) {
 
 	register_type(make_shared<XType>(&types, "c_string_t", sizeof(c_string_t), "", xray_string_fmt));
 	register_type(make_shared<XType>(&types, "c_p_string_t", sizeof(c_p_string_t), "", xray_p_string_fmt));
+	register_type(make_shared<XType>(&types, "ui_hex_t", sizeof(ui_hex_t), "0x%08x"));
 }
 
 
@@ -1244,3 +1245,4 @@ xray_handle_loop()
     }
     return 0;
 }
+

--- a/src/xray.h
+++ b/src/xray.h
@@ -29,6 +29,7 @@ extern "C"
 	/* typedefs */
 	typedef char * c_string_t;
 	typedef char ** c_p_string_t;
+	typedef unsigned int ui_hex_t;
 
 	typedef struct {
 		void *data;

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -38,16 +38,36 @@ class SystemTest(unittest.TestCase):
         pass
 
     def test_sanity(self):
-        self.assertEquals(self.libxray.create_type("test_type", sizeof(test_struct)), 0)
-        self.assertEquals(self.libxray.add_slot("test_type", "a", 0, 4, "int"), 0)
-        self.assertEquals(self.libxray.add_slot("test_type", "b", 4, 4, "int"), 0)
-        self.assertEquals(self.libxray.add_slot("test_type", "c", 8, 4, "int"), 0)
-        self.assertEquals(self.libxray.register("test_type", test_array, "/test", 10), 0)
+
+        self.assertEquals(self.libxray.create_type(
+            "test_type", sizeof(test_struct)), 0)
+
+        self.assertEquals(self.libxray.add_slot(
+            "test_type", "a", 0, 4, "int"), 0)
+
+        self.assertEquals(self.libxray.add_slot(
+            "test_type", "b", 4, 4, "int"), 0)
+
+        self.assertEquals(self.libxray.add_slot(
+            "test_type", "c", 8, 4, "ui_hex_t"), 0)
+
+        self.assertEquals(self.libxray.register(
+            "test_type", test_array, "/test", 10), 0)
+
         self.assertEquals(self.libxray.dump("/test"),
-                          [[u'a', u'b', u'c'], [u'1', u'1', u'1'], [u'1', u'1', u'1'], [u'1', u'1', u'1'],
-                           [u'1', u'1', u'1'], [u'1', u'1', u'1'], [u'1', u'1', u'1'], [u'1', u'1', u'1'],
-                           [u'1', u'1', u'1'], [u'1', u'1', u'1'], [u'1', u'1', u'1']])
+                          [[u'a', u'b', u'c'],
+                           [u'1', u'1', u'0x00000001'],
+                           [u'1', u'1', u'0x00000001'],
+                           [u'1', u'1', u'0x00000001'],
+                           [u'1', u'1', u'0x00000001'],
+                           [u'1', u'1', u'0x00000001'],
+                           [u'1', u'1', u'0x00000001'],
+                           [u'1', u'1', u'0x00000001'],
+                           [u'1', u'1', u'0x00000001'],
+                           [u'1', u'1', u'0x00000001'],
+                           [u'1', u'1', u'0x00000001']])
 
 
 if __name__ == '__main__':
     unittest.main()
+


### PR DESCRIPTION
sut_1  | -e I Starting unit tests''
sut_1  | XRAY_CONFIG: {}
sut_1  | effective config: {"api_key":"apikey","debug":"false","hostname":"756a5d68ef6b","port":"40001","server":"www.xrayio.com"}
sut_1  | Binding to: ipc:///tmp/xray/python ...
sut_1  | .
sut_1  | ----------------------------------------------------------------------
sut_1  | Ran 1 test in 0.003s
sut_1  |
sut_1  | OK
sut_1  | ...
sut_1  | ----------------------------------------------------------------------
sut_1  | Ran 3 tests in 2.455s
sut_1  |
sut_1  | OK
sut_1  | Starting TestApp /libxray/dist/test-app
sut_1  | TestApp is up
sut_1  |
sut_1  | stdout:
sut_1  | ['XRAY_CONFIG: {}\n', 'effective config: {"api_key":"04BE197BCBC14D8E","debug":"false","hostname":"756a5d68ef6b","port":"40001","server":"www.xrayio.com"}\n', 'Cannot create mount point\n', 'Binding to: ipc:///tmp/xray/test-app ...\n']
libxray_sut_1 exited with code 0